### PR TITLE
Add mgmt command to run Django migrations.

### DIFF
--- a/release_util/management/commands/run_migrations.py
+++ b/release_util/management/commands/run_migrations.py
@@ -1,0 +1,182 @@
+import sys
+import traceback
+import yaml
+from cStringIO import StringIO
+from timeit import default_timer
+from collections import defaultdict
+from copy import deepcopy
+
+from django.core.management import call_command, CommandError
+from django.core.management.base import BaseCommand
+from django.db.utils import DatabaseError
+
+
+class MigrationSession(object):
+    """
+    Class which is initialized with Django app/model migrations to perform.
+    Performs migrations while keeping track of the state of each migration.
+    Provides the state of all migrations on demand.
+    """
+    def __init__(self, input_yaml, stderr):
+        self.to_apply = []
+        self.migration_state = {
+            'success': [],
+            'failure': None,
+            'unapplied': [],
+            'rollback_commands': [],
+        }
+        self.timer = default_timer
+        self.stderr = stderr
+
+        # Load the passed-in YAML into a dictionary.
+        self.input_migrations = yaml.safe_load(input_yaml)
+
+        # Build a list of migrations to apply in order.
+        for migration in self.input_migrations['migrations']:
+            self.to_apply.append(migration)
+
+    def more_to_apply(self):
+        """
+        Returns True if more migrations remain to apply in this session, else False.
+        """
+        return len(self.to_apply) > 0
+
+    def _apply_next(self):
+        """
+        Applies the next-in-line Django model migration.
+        """
+        if not self.more_to_apply():
+            return
+
+        app, migration = self.to_apply.pop(0)
+
+        out = StringIO()
+        start = self.timer()
+        try:
+            call_command("migrate", app_label=app, migration_name=migration, noinput=True, stdout=out)
+        except (CommandError, DatabaseError) as e:
+            time_to_fail = self.timer() - start
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            self.stderr.write("Migration failed for app '{}' - migration '{}'.\n".format(app, migration))
+            # Assumed that only a single migration failure will occur.
+            self.migration_state['failure'] = {
+                'migration': [app, migration],
+                'duration': time_to_fail,
+                'output': out.getvalue(),
+                'traceback': repr(traceback.format_exception(exc_type, exc_value, exc_traceback)),
+            }
+            # Add the remaining migrations to the unapplied status.
+            while self.more_to_apply():
+                app_migration = self.to_apply.pop(0)
+                self.migration_state['unapplied'].append(app_migration)
+            # Find the apps that have been applied -or- failed.
+            # Include their initial migrations as commands.
+            apps_to_rollback = set()
+            # Add the apps with successfully applied migrations.
+            apps_to_rollback.update([k['migration'][0] for k in self.migration_state['success']])
+            # Add the failed app.
+            apps_to_rollback.add(app)
+            for app in apps_to_rollback:
+                self.migration_state['rollback_commands'].append(
+                    [
+                        'python', 'manage.py', 'migrate',
+                        app,
+                        self.input_migrations['initial_states'][app]
+                    ]
+                )
+            raise CommandError()
+
+        time_to_apply = self.timer() - start
+        self.migration_state['success'].append({
+            'migration': [app, migration],
+            'duration': time_to_apply,
+            'output': out.getvalue(),
+        })
+
+    def apply_all(self):
+        """
+        Apply all the migrations.
+        """
+        while self.more_to_apply():
+            self._apply_next()
+
+    def state(self):
+        """
+        Returns the current state as a YAML string.
+        """
+        return yaml.dump(self.migration_state)
+
+
+class Command(BaseCommand):
+    """
+    Given a YAML file containing apps and migrations, apply those app migrations.
+    The YAML format for the apps/migrations is:
+
+    migrations:
+      - [app1, 0001_initial]
+      - [app2, 0012_otherthing]
+      - [app1, 0002_somthing]
+    initial_states:
+      - app1:
+        - zero
+      - app2:
+        - 0011_beforetheotherthing
+
+    If an error occurs in any of the migrations, the migrations are halted at that point
+        and the status is recorded in an artifact.
+    The output of the command is in YAML format and specifies the following:
+        - migrations that run successfully and how long they took
+        - migrations that failed and how long the failure took
+        - migrations that unapplied due to previous failures
+    The output YAML format:
+
+    success:
+    - migration: [app1, 0001_initial]
+      duration: 3.45
+      output: All good!
+    failure:
+      migration: [app2, 0012_otherthing]
+      output: This migration has failed!!!!
+    unapplied:
+    - [app1, 0002_something]
+    rollback_commands:
+    - [python, manage.py, migrate, app1, zero]
+
+    If an output file is specified, the YAML output is also directed to that file.
+
+    Rollbacks due to migration failures are left to the mgmt command user.
+    """
+    help = "Given a YAML file containing apps and migrations, apply those app migrations."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'input_file',
+            type=unicode,
+            nargs='?',
+            help="Filename from which apps/migrations will be read."
+        )
+        parser.add_argument(
+            '--output_file',
+            dest='output_file',
+            default=None,
+            help="Filename to which migration results will be written."
+        )
+
+    def handle(self, *args, **kwargs):
+        with open(kwargs['input_file'], 'r') as f:
+            input_yaml = f.read()
+        migrator = MigrationSession(input_yaml, self.stderr)
+
+        failure = False
+        try:
+            migrator.apply_all()
+        except CommandError as e:
+            self.stderr.write("Migration error occurred.")
+            failure = True
+
+        self.stdout.write(migrator.state())
+        if kwargs['output_file']:
+            with open(kwargs['output_file'], 'w') as outfile:
+                outfile.write(migrator.state())
+
+        sys.exit(int(failure))

--- a/release_util/tests/tests.py
+++ b/release_util/tests/tests.py
@@ -3,9 +3,10 @@ from mock import patch, Mock
 import contextlib
 from path import Path as path
 import yaml
+import tempfile
 
 from django.test import TransactionTestCase
-from django.core.management import call_command
+from django.core.management import call_command, CommandError
 from django.db.utils import OperationalError
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.state import ProjectState
@@ -47,19 +48,48 @@ class MigrationCommandsTests(TransactionTestCase):
     """
     multi_db = True
 
-    def _check_command_output(self, cmd, cmd_kwargs, output, exit_value, yaml_output=False):
+    def _null_certain_fields(self, status):
+        """
+        When comparing the status of a migration run, some fields won't match the test data.
+        So set those fields to None before comparing.
+        """
+        def _null_migration_values(status):
+            if status:
+                for key in status.keys():
+                    if key in ('duration', 'output', 'traceback'):
+                        status[key] = None
+        for migration_data in status['success']:
+            _null_migration_values(migration_data)
+        _null_migration_values(status['failure'])
+        return status
+
+    def _check_command_output(self, cmd, cmd_args=(), cmd_kwargs={}, output='', err_output='', exit_value=0):
+        """
+        Run a mgmt command and perform comparisons on the output with what is expected.
+        """
         out = StringIO()
+        err = StringIO()
+        # Run command.
         with patch('sys.exit') as exit_mock:
-            call_command(cmd, stdout=out, verbosity=0, **cmd_kwargs)
+            call_command(cmd, stdout=out, stderr=err, verbosity=0, *cmd_args, **cmd_kwargs)
             self.assertTrue(exit_mock.called)
             exit_mock.assert_called_once_with(exit_value)
-        if yaml_output:
-            # Ensure the command output is parsable as YAML -and- is the expected YAML.
-            parsed_yaml = yaml.load(out.getvalue())
+        # Check command output.
+        if cmd in ('show_unapplied_migrations', 'run_migrations'):
+            parsed_yaml = yaml.safe_load(out.getvalue())
             self.assertTrue(isinstance(parsed_yaml, dict))
-            self.assertEqual(yaml.dump(output), yaml.dump(parsed_yaml))
+            if cmd == 'show_unapplied_migrations':
+                # Ensure the command output is parsable as YAML -and- is exactly the expected YAML.
+                self.assertEqual(yaml.dump(output), yaml.dump(parsed_yaml))
+            elif cmd == 'run_migrations':
+                # Don't compare all the fields - some fields will have variable output values.
+                parsed_yaml = self._null_certain_fields(parsed_yaml)
+                self.assertEqual(yaml.dump(output), yaml.dump(parsed_yaml))
         else:
             self.assertEqual(output, out.getvalue().replace('\n', ''))
+        # Check command error output.
+        self.assertEqual(err_output, err.getvalue().replace('\n', ''))
+
 
     def test_showmigrations_list(self):
         """
@@ -74,11 +104,16 @@ class MigrationCommandsTests(TransactionTestCase):
             (False, 0),
         ):
             self._check_command_output(
-                "show_unapplied_migrations",
-                {'fail_on_unapplied': fail_on_unapplied},
-                {'migrations': {'release_util': [u'0001_initial', u'0002_second']}},
-                exit_code,
-                yaml_output=True
+                cmd="show_unapplied_migrations",
+                cmd_kwargs={'fail_on_unapplied': fail_on_unapplied},
+                output={
+                    'initial_states': {'release_util': 'zero'},
+                    'migrations': [
+                        ['release_util', '0001_initial'],
+                        ['release_util', '0002_second'],
+                    ]
+                },
+                exit_value=exit_code
             )
 
         call_command("migrate", "release_util", "0001", verbosity=0)
@@ -88,11 +123,15 @@ class MigrationCommandsTests(TransactionTestCase):
             (False, 0),
         ):
             self._check_command_output(
-                "show_unapplied_migrations",
-                {'fail_on_unapplied': fail_on_unapplied},
-                {'migrations': {'release_util': [u'0002_second']}},
-                exit_code,
-                yaml_output=True
+                cmd="show_unapplied_migrations",
+                cmd_kwargs={'fail_on_unapplied': fail_on_unapplied},
+                output={
+                    'initial_states': {'release_util': '0001_initial'},
+                    'migrations': [
+                        ['release_util', '0002_second']
+                    ]
+                },
+                exit_value=exit_code
             )
 
         call_command("migrate", "release_util", "0002", verbosity=0)
@@ -102,11 +141,13 @@ class MigrationCommandsTests(TransactionTestCase):
             (False, 0),
         ):
             self._check_command_output(
-                "show_unapplied_migrations",
-                {'fail_on_unapplied': fail_on_unapplied},
-                {'migrations': {}},
-                exit_code,
-                yaml_output=True
+                cmd="show_unapplied_migrations",
+                cmd_kwargs={'fail_on_unapplied': fail_on_unapplied},
+                output={
+                    'initial_states': {},
+                    'migrations': []
+                },
+                exit_value=exit_code
             )
 
         # Cleanup by unmigrating everything
@@ -120,10 +161,9 @@ class MigrationCommandsTests(TransactionTestCase):
         """
         with remove_and_restore_models([('release_util', 'book'), ('release_util', 'author')]):
             self._check_command_output(
-                "detect_missing_migrations",
-                {},
-                "Checking...Apps with model changes but no corresponding migration file: ['release_util']",
-                1
+                cmd="detect_missing_migrations",
+                output="Checking...Apps with model changes but no corresponding migration file: ['release_util']",
+                exit_value=1
             )
 
     def test_no_missing_migrations(self):
@@ -131,8 +171,112 @@ class MigrationCommandsTests(TransactionTestCase):
         In the current repo state, verify that there are no missing migrations.
         """
         self._check_command_output(
-            "detect_missing_migrations",
-            {},
-            "Checking...All migration files present.",
-            0
+            cmd="detect_missing_migrations",
+            output="Checking...All migration files present.",
         )
+
+    def test_run_migrations_success(self):
+        """
+        Test the migration success path.
+        """
+        # Using TransactionTestCase sets up the migrations as set up for the test.
+        # Reset the release_util migrations to the very beginning - i.e. no tables.
+        call_command("migrate", "release_util", "zero", verbosity=0)
+
+        input_yaml = """
+        migrations:
+          - [release_util, 0001_initial]
+          - [release_util, 0002_second]
+        initial_states:
+          - release_util:
+            - zero
+        """
+        output = {
+            'success': [
+                {
+                    'migration': ['release_util', '0001_initial'],
+                    'duration': None,
+                    'output': None
+                },
+                {
+                    'migration': ['release_util', '0002_second'],
+                    'duration': None,
+                    'output': None
+                },
+            ],
+            'failure': None,
+            'unapplied': [],
+            'rollback_commands': [],
+        }
+
+        out_file = tempfile.NamedTemporaryFile(suffix='.yml')
+        in_file = tempfile.NamedTemporaryFile(suffix='.yml')
+        in_file.write(input_yaml)
+        in_file.flush()
+
+        # Check the stdout output against the expected output.
+        self._check_command_output(
+            cmd="run_migrations",
+            cmd_args=(in_file.name,),
+            cmd_kwargs={'output_file': out_file.name},
+            output=output,
+        )
+        in_file.close()
+
+        # Check the contents of the output file against the expected output.
+        with open(out_file.name, 'r') as f:
+            output_yaml = f.read()
+        parsed_yaml = yaml.safe_load(output_yaml)
+        self.assertTrue(isinstance(parsed_yaml, dict))
+        parsed_yaml = self._null_certain_fields(parsed_yaml)
+        self.assertEqual(yaml.dump(output), yaml.dump(parsed_yaml))
+        out_file.close()
+
+    def test_run_migrations_failure(self):
+        """
+        Test the first migration failing.
+        """
+        # Using TransactionTestCase sets up the migrations as set up for the test.
+        # Reset the release_util migrations to the very beginning - i.e. no tables.
+        call_command("migrate", "release_util", "zero", verbosity=0)
+
+        input_yaml = """
+        migrations:
+          - [release_util, 0001_initial]
+          - [release_util, 0002_second]
+        initial_states: {release_util: zero}
+        """
+        output = {
+            'success': [],
+            'failure': {
+                'migration': ['release_util', '0001_initial'],
+                'duration': None,
+                'output': None,
+                'traceback': None,
+            },
+            'unapplied': [
+                ['release_util', '0002_second'],
+            ],
+            'rollback_commands': [
+                ['python', 'manage.py', 'migrate', 'release_util', 'zero'],
+            ],
+        }
+
+        out_file = tempfile.NamedTemporaryFile(suffix='.yml')
+        in_file = tempfile.NamedTemporaryFile(suffix='.yml')
+        in_file.write(input_yaml)
+        in_file.flush()
+
+        with patch('django.core.management.commands.migrate.Command.handle') as handle_mock:
+            handle_mock.side_effect = CommandError("BIG ERROR!")
+            # Check the stdout output.
+            self._check_command_output(
+                cmd="run_migrations",
+                cmd_args=(in_file.name,),
+                cmd_kwargs={'output_file': out_file.name},
+                output=output,
+                err_output="Migration failed for app 'release_util' - migration '0001_initial'.Migration error occurred.",
+                exit_value=1
+            )
+        in_file.close()
+        out_file.close()


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TE-1178

The new script required some changes to the previously-implemented script that found all unapplied migrations. The script should apply the migrations for all apps that are specified in the specified order. If failures occur, appropriate information should be captured.

Things to point out:
- Known testing hole: There's only a single app with two migrations in my tests - but the script is designed to handle multiple apps with multiple migrations.
- There are no tests that call both mgmt commands and pipe the output of one into the input of the other.

@edx/pipeline-team Please review.