### PR TITLE
Always include rollback commands.

### DIFF
--- a/release_util/management/commands/show_unapplied_migrations.py
+++ b/release_util/management/commands/show_unapplied_migrations.py
@@ -84,13 +84,14 @@ class Command(BaseCommand):
         If no migrations have been performed, return 'zero' as the most recent migration for the app.
         """
         # Only care about applied migrations for the passed-in apps.
+        apps = set(apps)
         relevant_applied = [migration for migration in loader.applied_migrations if migration[0] in apps]
         # Sort them by the most recent migration and convert to a dictionary,
         # leaving apps as keys and most recent migration as values.
         most_recents = dict(sorted(relevant_applied, key=lambda m: m[1], reverse=True))
         # Fill in the apps with no migrations with 'zero'.
         # NOTE: Unicode Django application names are unsupported.
-        most_recents = {app: 'zero' if not app in most_recents else str(most_recents[app]) for app in apps}
+        most_recents = [[app, 'zero' if not app in most_recents else str(most_recents[app])] for app in apps]
         return most_recents
 
     def _gather_migration_info(self, *args, **kwargs):

--- a/release_util/tests/tests.py
+++ b/release_util/tests/tests.py
@@ -107,7 +107,7 @@ class MigrationCommandsTests(TransactionTestCase):
                 cmd="show_unapplied_migrations",
                 cmd_kwargs={'fail_on_unapplied': fail_on_unapplied},
                 output={
-                    'initial_states': {'release_util': 'zero'},
+                    'initial_states': [['release_util', 'zero']],
                     'migrations': [
                         ['release_util', '0001_initial'],
                         ['release_util', '0002_second'],
@@ -126,7 +126,7 @@ class MigrationCommandsTests(TransactionTestCase):
                 cmd="show_unapplied_migrations",
                 cmd_kwargs={'fail_on_unapplied': fail_on_unapplied},
                 output={
-                    'initial_states': {'release_util': '0001_initial'},
+                    'initial_states': [['release_util', '0001_initial']],
                     'migrations': [
                         ['release_util', '0002_second']
                     ]
@@ -144,7 +144,7 @@ class MigrationCommandsTests(TransactionTestCase):
                 cmd="show_unapplied_migrations",
                 cmd_kwargs={'fail_on_unapplied': fail_on_unapplied},
                 output={
-                    'initial_states': {},
+                    'initial_states': [],
                     'migrations': []
                 },
                 exit_value=exit_code
@@ -188,8 +188,7 @@ class MigrationCommandsTests(TransactionTestCase):
           - [release_util, 0001_initial]
           - [release_util, 0002_second]
         initial_states:
-          - release_util:
-            - zero
+          - [release_util, zero]
         """
         output = {
             'success': [
@@ -206,7 +205,9 @@ class MigrationCommandsTests(TransactionTestCase):
             ],
             'failure': None,
             'unapplied': [],
-            'rollback_commands': [],
+            'rollback_commands': [
+                ['python', 'manage.py', 'migrate', 'release_util', 'zero'],
+            ],
         }
 
         out_file = tempfile.NamedTemporaryFile(suffix='.yml')
@@ -244,7 +245,8 @@ class MigrationCommandsTests(TransactionTestCase):
         migrations:
           - [release_util, 0001_initial]
           - [release_util, 0002_second]
-        initial_states: {release_util: zero}
+        initial_states:
+          - [release_util, zero]
         """
         output = {
             'success': [],
@@ -275,7 +277,7 @@ class MigrationCommandsTests(TransactionTestCase):
                 cmd_args=(in_file.name,),
                 cmd_kwargs={'output_file': out_file.name},
                 output=output,
-                err_output="Migration failed for app 'release_util' - migration '0001_initial'.Migration error occurred.",
+                err_output="Migration error: Migration failed for app 'release_util' - migration '0001_initial'.",
                 exit_value=1
             )
         in_file.close()


### PR DESCRIPTION
Include rollback commands upon migration success *and* failure. Also, change structure of initial migration states from a list of dicts to a list of lists.

@edx/pipeline-team Please review.