### PR TITLE
Update PyPI automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,13 @@ install: "pip install -r requirements/test.txt"
 
 # command to run tests
 script: python manage.py test
+
+# publish to PyPI on new tag
+deploy:
+  provider: pypi
+  user: edx
+  password:
+    secure: A2BrU6qqQHSrJ7jvxOSr1/l4HdHT5EvRWvkufMR+kdq8I8qgTlGio22Tc4OSrD5Oe7Zz7ST7q3fJFRf8Kt/gdZp7DJeeVR5gK113EvquYQUdb+wbKiBHQ3hu7JBWAjrzUQ3mDPk5DJN77dUVByYoZUmWQVMyg2fmUnQxRdertLI=
+  distributions: sdist bdist_wheel
+  on:
+    tags: true


### PR DESCRIPTION
@doctoryes It struck me that we don't want to be uploading to PyPI manually every time this package is upgraded, so I've followed the instructions at https://openedx.atlassian.net/wiki/display/OpenOPS/Publishing+a+Package+to+PyPI+using+Travis to make Travis do it for us.

Feel free to merge at your convenience, then we'll have a version on PyPI as soon as a `0.0.1` tag is created.