### PR TITLE
Make sure README.md is included in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
@doctoryes The PyPI package failed on one of our Travis builds due to README.md not being included in the package distribution by default (it will include `README` or `README.txt` if those exist, heaven forbid you want to use Markup).

Once this is merged I'll re-push the 0.0.1 tag once more.

Failing build seen here: https://travis-ci.org/edx/course-discovery/builds/143410589

Local verification that `README.md` is now included:
```
ericfischer@dhcp-18-189-11-166:~/tmp_code/edx-django-release-util$ python setup.py sdist
running sdist
running egg_info
writing requirements to edx_django_release_util.egg-info/requires.txt
writing edx_django_release_util.egg-info/PKG-INFO
writing top-level names to edx_django_release_util.egg-info/top_level.txt
writing dependency_links to edx_django_release_util.egg-info/dependency_links.txt
reading manifest file 'edx_django_release_util.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'edx_django_release_util.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt

running check
creating edx-django-release-util-0.0.1
creating edx-django-release-util-0.0.1/edx_django_release_util.egg-info
creating edx-django-release-util-0.0.1/release_util
creating edx-django-release-util-0.0.1/release_util/management
creating edx-django-release-util-0.0.1/release_util/management/commands
creating edx-django-release-util-0.0.1/release_util/tests
creating edx-django-release-util-0.0.1/release_util/tests/migrations
creating edx-django-release-util-0.0.1/release_util/tests/migrations/test_migrations
making hard links in edx-django-release-util-0.0.1...
hard linking MANIFEST.in -> edx-django-release-util-0.0.1
hard linking README.md -> edx-django-release-util-0.0.1
hard linking setup.py -> edx-django-release-util-0.0.1
hard linking edx_django_release_util.egg-info/PKG-INFO -> edx-django-release-util-0.0.1/edx_django_release_util.egg-info
hard linking edx_django_release_util.egg-info/SOURCES.txt -> edx-django-release-util-0.0.1/edx_django_release_util.egg-info
hard linking edx_django_release_util.egg-info/dependency_links.txt -> edx-django-release-util-0.0.1/edx_django_release_util.egg-info
hard linking edx_django_release_util.egg-info/requires.txt -> edx-django-release-util-0.0.1/edx_django_release_util.egg-info
hard linking edx_django_release_util.egg-info/top_level.txt -> edx-django-release-util-0.0.1/edx_django_release_util.egg-info
hard linking release_util/__init__.py -> edx-django-release-util-0.0.1/release_util
hard linking release_util/management/__init__.py -> edx-django-release-util-0.0.1/release_util/management
hard linking release_util/management/commands/__init__.py -> edx-django-release-util-0.0.1/release_util/management/commands
hard linking release_util/management/commands/detect_missing_migrations.py -> edx-django-release-util-0.0.1/release_util/management/commands
hard linking release_util/management/commands/run_migrations.py -> edx-django-release-util-0.0.1/release_util/management/commands
hard linking release_util/management/commands/show_unapplied_migrations.py -> edx-django-release-util-0.0.1/release_util/management/commands
hard linking release_util/tests/migrations/__init__.py -> edx-django-release-util-0.0.1/release_util/tests/migrations
hard linking release_util/tests/migrations/test_migrations/0001_initial.py -> edx-django-release-util-0.0.1/release_util/tests/migrations/test_migrations
hard linking release_util/tests/migrations/test_migrations/0002_second.py -> edx-django-release-util-0.0.1/release_util/tests/migrations/test_migrations
hard linking release_util/tests/migrations/test_migrations/__init__.py -> edx-django-release-util-0.0.1/release_util/tests/migrations/test_migrations
Writing edx-django-release-util-0.0.1/setup.cfg
Creating tar archive
removing 'edx-django-release-util-0.0.1' (and everything under it)
```