### PR TITLE
Use yaml.safe_dump() instead of yaml.dump().

### DIFF
--- a/release_util/__init__.py
+++ b/release_util/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.1.1'  # pragma: no cover
+__version__ = '0.1.2'  # pragma: no cover

--- a/release_util/management/commands/__init__.py
+++ b/release_util/management/commands/__init__.py
@@ -129,7 +129,7 @@ class MigrationSessionDeprecated(object):
         """
         Returns the current state as a YAML string.
         """
-        return yaml.dump(self.migration_state)
+        return yaml.safe_dump(self.migration_state)
 
 
 class MigrationSession(object):
@@ -292,4 +292,4 @@ class MigrationSession(object):
         """
         Returns the current state as a YAML string.
         """
-        return yaml.dump(self.migration_state)
+        return yaml.safe_dump(self.migration_state)

--- a/release_util/management/commands/show_unapplied_migrations.py
+++ b/release_util/management/commands/show_unapplied_migrations.py
@@ -110,7 +110,7 @@ class Command(BaseCommand):
         migration_info = self._gather_migration_info(self, *args, **kwargs)
 
         # Compose the output YAML.
-        yaml_output = yaml.dump(migration_info)
+        yaml_output = yaml.safe_dump(migration_info)
 
         # Output the composed YAML.
         self.stdout.write(yaml_output)


### PR DESCRIPTION
Details here:
https://openedx.atlassian.net/browse/TE-1745

It looks as if other IDAs have run migrations successfully without this change - apparently because their Django app names have never been Unicode:
https://gocd.tools.edx.org/go/pipelines/stage-edx-discovery/113/apply_migrations/2

edx-platform is special yet again - I've gotten a failure migrating there because of Unicode app names:
https://gocd.tools.edx.org/go/tab/build/detail/LOADTEST_edxapp_Build_Migrate_Deploy/12/apply_migrations_cms/1/apply_migrations_job

@edx/pipeline-team PTAL.