### PR TITLE
Since we cannot count on set ordering staying stable, convert to a list

### DIFF
--- a/release_util/__init__.py
+++ b/release_util/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.2'  # pragma: no cover
+__version__ = '0.3.3'  # pragma: no cover

--- a/release_util/management/commands/__init__.py
+++ b/release_util/management/commands/__init__.py
@@ -191,7 +191,8 @@ class MigrationSession(object):
         This should only be called from list_migrations().
         """
         # Only care about applied migrations for the passed-in apps.
-        apps = set(apps)
+        # Remove duplicates and preserve order of the list.
+        apps = [app for index, app in enumerate(apps) if app not in apps[:index]]
         relevant_applied = [migration for migration in loader.applied_migrations if migration[0] in apps]
         # Sort them by the most recent migration and convert to a dictionary,
         # leaving apps as keys and most recent migration as values.


### PR DESCRIPTION
with the duplicates removed.

https://openedx.atlassian.net/browse/BOM-1129

This is breaking the bokchoy db caching job because the ordering changes every time the job is run. 