### PR TITLE
Fix inserts for generate_history cmd for columns containing reserved …

### DIFF
--- a/release_util/__init__.py
+++ b/release_util/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '0.3.5'  # pragma: no cover
+__version__ = '0.3.6'  # pragma: no cover

--- a/release_util/management/commands/generate_history.py
+++ b/release_util/management/commands/generate_history.py
@@ -116,8 +116,11 @@ class Command(BaseCommand):
                             """.format(
                                 table=table,
                                 historical_table=historical_table,
-                                insert_columns=','.join(columns),
-                                select_columns=','.join(['t.{}'.format(c) for c in columns]),
+                                # this cmd fails for tables containing reserved keywords in column.
+                                # https://dev.mysql.com/doc/refman/5.5/en/glossary.html
+                                # Backticked columns to avoid MYSQL errors
+                                insert_columns=','.join(['`{}`'.format(c) for c in columns]),
+                                select_columns=','.join(['t.`{}`'.format(c) for c in columns]),
                                 history_date=self.HISTORY_DATE,
                                 history_change_reason=self.HISTORY_CHANGE_REASON,
                                 history_user_id=self.HISTORY_USER_ID,


### PR DESCRIPTION
Fix `generate_history` command for columns still using reserved keywords in MySQL