### PR TITLE
Updated Python and Django versions in Tox and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,12 @@ sudo: false
 language: python
 
 python:
-  - 2.7
   - 3.5
-  - 3.6
-  - 3.7
   - 3.8
 
 env:
-  - TOXENV=django111
-  - TOXENV=django20
-  - TOXENV=django21
+  - TOXENV=quality
   - TOXENV=django22
-
-jobs:
-  include:
-    - python: 3.6
-      env: TOXENV=quality
-  exclude:
-    - python: 2.7
-      env: TOXENV=django20
-    - python: 2.7
-      env: TOXENV=django21
-    - python: 2.7
-      env: TOXENV=django22
 
 cache:
   - pip

--- a/release_util/__init__.py
+++ b/release_util/__init__.py
@@ -2,4 +2,4 @@
 a collection of Django management commands used for analyzing and manipulating migrations.
 """
 
-__version__ = '0.4.2'  # pragma: no cover
+__version__ = '0.4.3'  # pragma: no cover

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
-Django>=1.11              # Web application framework
+Django              # Web application framework
 PyYAML
 six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-django==2.2.11            # via -c requirements/constraints.txt, -r requirements/base.in
-pytz==2019.3              # via django
-pyyaml==5.3               # via -c requirements/constraints.txt, -r requirements/base.in
-six==1.14.0               # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in
+pytz==2020.1              # via django
+pyyaml==5.3.1             # via -r requirements/base.in
+six==1.14.0               # via -r requirements/base.in
 sqlparse==0.3.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,33 +8,9 @@
 # pin when possible. Writing an issue against the offending project and
 # linking to it here is good.
 
-# pytest 5.0.0 drops support for python 2.7.  Remove this constraint once we
-# fully drop support for python 2.7 in all IDAs that include this app.
-pytest<5.0.0
-
-# more-itertools 6.0.0 drops support for python 2.7.  Remove this constraint
-# once we fully drop support for python 2.7 in all IDAs that include this app.
-more-itertools<6.0.0
-
-# path.py 12.0 (renamed to "path" in 13.0.0) drops support for python 2.7.
-# Remove this constraint once we fully drop support for python 2.7 in all IDAs
-# that include this app.
-path.py<12.0
-
-# Django 3.x introduces a new requirement, asgiref, which practically has no
-# version that supports python 2.7.  Remove this constraint once we fully drop
-# support for python 2.7 in all IDAs that include this app.
-Django<3.0.0
-
-# zipp 2.0.0 drops support for python 2.7.  Remove this constraint once we
-# fully drop support for python 2.7 in all IDAs that include this app.
-zipp<2.0.0
-
 # mock 4.0.0 drops support for python 3.5.  Remove this constraint once we
 # fully drop support for python 3.5 in all IDAs that include this app.
 mock<4.0.0
 
-# For some reason unclear to me, these were constrained before I overhauled
-# requirements.
-PyYAML>=3.11
-six>=1.10.0
+# staying on an lts release
+django<2.3

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,6 +4,9 @@
 #
 #    make upgrade
 #
-click==7.1.1              # via pip-tools
-pip-tools==4.5.1          # via -r requirements/pip_tools.in
-six==1.14.0               # via -c requirements/constraints.txt, pip-tools
+click==7.1.2              # via pip-tools
+pip-tools==5.1.0          # via -r requirements/pip_tools.in
+six==1.14.0               # via pip-tools
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,38 +5,39 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via -r requirements/test.txt, virtualenv
-atomicwrites==1.3.0       # via -r requirements/test.txt, pytest
 attrs==19.3.0             # via -r requirements/test.txt, pytest
-coverage==5.0.3           # via -r requirements/test.txt, pytest-cov
-ddt==1.3.0                # via -r requirements/test.txt
+coverage==5.1             # via -r requirements/test.txt, pytest-cov
+ddt==1.3.1                # via -r requirements/test.txt
 distlib==0.3.0            # via -r requirements/test.txt, virtualenv
 django-nose==1.4.6        # via -r requirements/test.txt
 django-waffle==0.20.0     # via -r requirements/test.txt
-django==2.2.11            # via -c requirements/constraints.txt, -r requirements/test.txt
+django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
-importlib-metadata==1.5.0  # via -r requirements/test.txt, importlib-resources, path.py, pluggy, pytest, tox, virtualenv
-importlib-resources==1.3.1  # via -r requirements/test.txt, virtualenv
+importlib-metadata==1.6.0  # via -r requirements/test.txt, importlib-resources, path, pluggy, pytest, tox, virtualenv
+importlib-resources==1.5.0  # via -r requirements/test.txt, virtualenv
 isort==4.3.21             # via -r requirements/quality.in
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.txt
-more-itertools==5.0.0     # via -c requirements/constraints.txt, -r requirements/test.txt, pytest
+more-itertools==8.2.0     # via -r requirements/test.txt, pytest
 nose==1.3.7               # via -r requirements/test.txt, django-nose
 packaging==20.3           # via -r requirements/test.txt, pytest, tox
-path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/test.txt
+path.py==12.4.0           # via -r requirements/test.txt
+path==13.1.0              # via -r requirements/test.txt, path.py
+pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 py==1.8.1                 # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.5.0        # via -r requirements/quality.in
 pydocstyle==5.0.2         # via -r requirements/quality.in
-pyparsing==2.4.6          # via -r requirements/test.txt, packaging
+pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
-pytest-django==3.8.0      # via -r requirements/test.txt
-pytest==4.6.9             # via -c requirements/constraints.txt, -r requirements/test.txt, pytest-cov, pytest-django
-pytz==2019.3              # via -r requirements/test.txt, django
-pyyaml==5.3               # via -c requirements/constraints.txt, -r requirements/test.txt
-six==1.14.0               # via -c requirements/constraints.txt, -r requirements/test.txt, django-waffle, mock, more-itertools, packaging, pytest, tox, virtualenv
+pytest-django==3.9.0      # via -r requirements/test.txt
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytz==2020.1              # via -r requirements/test.txt, django
+pyyaml==5.3.1             # via -r requirements/test.txt
+six==1.14.0               # via -r requirements/test.txt, django-waffle, mock, packaging, pathlib2, tox, virtualenv
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 toml==0.10.0              # via -r requirements/test.txt, tox
-tox==3.14.5               # via -r requirements/test.txt
-virtualenv==20.0.10       # via -r requirements/test.txt, tox
-wcwidth==0.1.8            # via -r requirements/test.txt, pytest
-zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/test.txt, importlib-metadata, importlib-resources
+tox==3.14.6               # via -r requirements/test.txt
+virtualenv==20.0.18       # via -r requirements/test.txt, tox
+wcwidth==0.1.9            # via -r requirements/test.txt, pytest
+zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources

--- a/requirements/scripts.txt
+++ b/requirements/scripts.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-certifi==2019.11.28       # via requests
+certifi==2020.4.5.1       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
-click==7.1.1              # via -r requirements/scripts.in
-cryptography==2.8         # via jwcrypto
+click==7.1.2              # via -r requirements/scripts.in
+cryptography==2.9.2       # via jwcrypto
 github3.py==1.3.0         # via -r requirements/scripts.in
 idna==2.9                 # via requests
 jwcrypto==0.7             # via github3.py
 pycparser==2.20           # via cffi
 python-dateutil==2.8.1    # via github3.py
 requests==2.23.0          # via github3.py
-six==1.14.0               # via -c requirements/constraints.txt, cryptography, python-dateutil
+six==1.14.0               # via cryptography, python-dateutil
 uritemplate==3.0.1        # via github3.py
-urllib3==1.25.8           # via requests
+urllib3==1.25.9           # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,33 +5,34 @@
 #    make upgrade
 #
 appdirs==1.4.3            # via virtualenv
-atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest
-coverage==5.0.3           # via pytest-cov
-ddt==1.3.0                # via -r requirements/test.in
+coverage==5.1             # via pytest-cov
+ddt==1.3.1                # via -r requirements/test.in
 distlib==0.3.0            # via virtualenv
 django-nose==1.4.6        # via -r requirements/test.in
 django-waffle==0.20.0     # via -r requirements/test.in
 filelock==3.0.12          # via tox, virtualenv
-importlib-metadata==1.5.0  # via importlib-resources, path.py, pluggy, pytest, tox, virtualenv
-importlib-resources==1.3.1  # via virtualenv
+importlib-metadata==1.6.0  # via importlib-resources, path, pluggy, pytest, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
-more-itertools==5.0.0     # via -c requirements/constraints.txt, pytest
+more-itertools==8.2.0     # via pytest
 nose==1.3.7               # via django-nose
 packaging==20.3           # via pytest, tox
-path.py==11.5.2           # via -c requirements/constraints.txt, -r requirements/test.in
+path.py==12.4.0           # via -r requirements/test.in
+path==13.1.0              # via path.py
+pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest, tox
 py==1.8.1                 # via pytest, tox
-pyparsing==2.4.6          # via packaging
+pyparsing==2.4.7          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.8.0      # via -r requirements/test.in
-pytest==4.6.9             # via -c requirements/constraints.txt, -r requirements/test.in, pytest-cov, pytest-django
-pytz==2019.3              # via -r requirements/base.txt, django
-pyyaml==5.3               # via -c requirements/constraints.txt, -r requirements/base.txt
-six==1.14.0               # via -c requirements/constraints.txt, -r requirements/base.txt, django-waffle, mock, more-itertools, packaging, pytest, tox, virtualenv
+pytest-django==3.9.0      # via -r requirements/test.in
+pytest==5.4.1             # via -r requirements/test.in, pytest-cov, pytest-django
+pytz==2020.1              # via -r requirements/base.txt, django
+pyyaml==5.3.1             # via -r requirements/base.txt
+six==1.14.0               # via -r requirements/base.txt, django-waffle, mock, packaging, pathlib2, tox, virtualenv
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 toml==0.10.0              # via tox
-tox==3.14.5               # via -r requirements/test.in
-virtualenv==20.0.10       # via tox
-wcwidth==0.1.8            # via pytest
-zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources
+tox==3.14.6               # via -r requirements/test.in
+virtualenv==20.0.18       # via tox
+wcwidth==0.1.9            # via pytest
+zipp==1.2.0               # via importlib-metadata, importlib-resources

--- a/setup.py
+++ b/setup.py
@@ -61,13 +61,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38}-django{111}, py{35,36,37,38}-django{20,21,22}
+envlist = py35-django22, py38-django{22,30}
 
 [pycodestyle]
 exclude = .git,.tox,migrations
@@ -34,10 +34,8 @@ setenv =
     # This allows us to reference test_settings.py
     PYTHONPATH = {toxinidir}
 deps =
-    django111: Django>=1.11
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     -rrequirements/test.txt
     -rrequirements/scripts.txt
 commands =


### PR DESCRIPTION
**Issue:** [BOM-1556](https://openedx.atlassian.net/browse/BOM-1556)

### Description
- Removed `py27`, `py36`, `py37`, `django<2.2` from **Travis** and **Tox**.
- Added `django30` in **Tox**.
- Updated Constraints. 
- Updated version to `0.4.3`.