### PR TITLE
Adding new release to PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,5 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    python: 3.5
     condition: '$TOXENV = quality'

--- a/release_util/__init__.py
+++ b/release_util/__init__.py
@@ -2,4 +2,4 @@
 a collection of Django management commands used for analyzing and manipulating migrations.
 """
 
-__version__ = '0.4.3'  # pragma: no cover
+__version__ = '0.4.4'  # pragma: no cover


### PR DESCRIPTION
Created new tag `0.4.4` for PyPi release.