### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ __ http://code.edx.org/
 
 edX Django Release Utilities  |Travis|_ 
 =======================================
-.. |Travis| image:: https://travis-ci.org/edx/edx-django-release-util.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/edx-django-release-util?branch=master
+.. |Travis| image:: https://travis-ci.com/edx/edx-django-release-util.svg?branch=master
+.. _Travis: https://travis-ci.com/edx/edx-django-release-util?branch=master
 
 Release pipeline utilities for edX independently-deployable applications (IDAs) based on Django.
 


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089